### PR TITLE
Fix: labels not showing up in modify relation dialog

### DIFF
--- a/skiros2_gui/src/skiros2_gui/core/skiros_widget.py
+++ b/skiros2_gui/src/skiros2_gui/core/skiros_widget.py
@@ -106,8 +106,8 @@ class SkirosModifyRelationDialog(QDialog):
         size_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         comboBox.setSizePolicy(size_policy)
         for alias, key in elements.items():
-            label = self.parent()._wmi.get_element(key).label if self.parent()._wmi.is_scene_element(key) else ""
-            comboBox.addItem("{} {}".format(alias, label), key)
+            element_label = self.parent()._wmi.get_element(key).label if self.parent()._wmi.is_scene_element(key) else ""
+            comboBox.addItem("{} {}".format(alias, element_label), key)
         comboBox.model().sort(0)
         self.formLayout.insertRow(len(self._rows), label, comboBox)
         self._rows.append(comboBox)


### PR DESCRIPTION
Fix name collision causing labels for the combo boxes to not show up when modifying relations.