### PR TITLE
Conditional dependencies for rdflib

### DIFF
--- a/skiros2_world_model/package.xml
+++ b/skiros2_world_model/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>skiros2_world_model</name>
   <version>1.0.4</version>
   <description>SkiROS semantic database</description>
@@ -14,8 +14,9 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
   <build_depend>skiros2_msgs</build_depend>
-  <run_depend>python-rdflib</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>skiros2_msgs</run_depend>
-  <run_depend>skiros2_common</run_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rdflib</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rdflib</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>skiros2_msgs</exec_depend>
+  <exec_depend>skiros2_common</exec_depend>
 </package>


### PR DESCRIPTION
Addresses issue #29. Commit https://github.com/RVMI/skiros2/commit/b938905746c99d3c3d20c879f4bf202ee4078b55 uses rosdep to install rdflib but does not work with python 3. This PR uses conditional dependencies for different python versions.  