### PR TITLE
rdflib requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 wrapt
 inflection
+rdflib


### PR DESCRIPTION
skiros2_world_model/core/ontology_rdflib.py depends on rdflib