### PR TITLE
Change camelCasing to underscore for class methods

### DIFF
--- a/skiros2_skill/nodes/utils/cmd
+++ b/skiros2_skill/nodes/utils/cmd
@@ -16,9 +16,9 @@ if __name__ == '__main__':
             wait = True
         wmi = wmi.WorldModelInterface()
         sli = sli.SkillLayerInterface()
-        agent = sli.getAgent(mgr)
+        agent = sli.get_agent(mgr)
         if action == "start":
-            eid = agent.execute([agent.getSkill(skill)], "cmd_line_tool")
+            eid = agent.execute([agent.get_skill(skill)], "cmd_line_tool")
             if wait:
                 agent.waitResult(eid)  # Bugged
             else:

--- a/skiros2_skill/src/skiros2_skill/ros/skill_layer_interface.py
+++ b/skiros2_skill/src/skiros2_skill/ros/skill_layer_interface.py
@@ -83,4 +83,4 @@ class SkillLayerInterface(DiscoveryInterface):
 
     def print_state(self):
         for k, a in self._agents.items():
-            print(k + ":" + a.printState())
+            print(k + ":" + a.print_state())


### PR DESCRIPTION
I came across two examples of methods that use camel casing where their definitions use underscore notation.
There are more inconsistencies in the naming of methods throughout the code, e.g. most files in `skiros2_common/src/skiros2_common/core/` use camelCasing.
If you'd like to migrate to underscore notation for all methods; please let me know if there are files you'd like to exclude from that transition, or if other restrictions apply, and I'd be happy to help.