### PR TITLE
cfg files use underscore instead of dash as required by setuptools

### DIFF
--- a/skiros2/setup.cfg
+++ b/skiros2/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/skiros2
+script_dir=$base/lib/skiros2
 [install]
-install-scripts=$base/lib/skiros2
+install_scripts=$base/lib/skiros2

--- a/skiros2_common/setup.cfg
+++ b/skiros2_common/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/skiros2_common
+script_dir=$base/lib/skiros2_common
 [install]
-install-scripts=$base/lib/skiros2_common
+install_scripts=$base/lib/skiros2_common

--- a/skiros2_gui/setup.cfg
+++ b/skiros2_gui/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/skiros2_gui
+script_dir=$base/lib/skiros2_gui
 [install]
-install-scripts=$base/lib/skiros2_gui
+install_scripts=$base/lib/skiros2_gui

--- a/skiros2_msgs/setup.cfg
+++ b/skiros2_msgs/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/skiros2_msgs
+script_dir=$base/lib/skiros2_msgs
 [install]
-install-scripts=$base/lib/skiros2_msgs
+install_scripts=$base/lib/skiros2_msgs

--- a/skiros2_skill/setup.cfg
+++ b/skiros2_skill/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/skiros2_skill
+script_dir=$base/lib/skiros2_skill
 [install]
-install-scripts=$base/lib/skiros2_skill
+install_scripts=$base/lib/skiros2_skill

--- a/skiros2_task/setup.cfg
+++ b/skiros2_task/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/skiros2_task
+script_dir=$base/lib/skiros2_task
 [install]
-install-scripts=$base/lib/skiros2_task
+install_scripts=$base/lib/skiros2_task

--- a/skiros2_world_model/setup.cfg
+++ b/skiros2_world_model/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/skiros2_world_model
+script_dir=$base/lib/skiros2_world_model
 [install]
-install-scripts=$base/lib/skiros2_world_model
+install_scripts=$base/lib/skiros2_world_model


### PR DESCRIPTION
`
~/.local/lib/python3.8/site-packages/setuptools/dist.py:739: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
`

https://setuptools.pypa.io/en/latest/history.html#v54-1-0 