### PR TITLE
Fix: WM: More iterations for overlapping keys merge

### DIFF
--- a/skiros2_world_model/src/skiros2_world_model/ros/world_model_interface.py
+++ b/skiros2_world_model/src/skiros2_world_model/ros/world_model_interface.py
@@ -596,11 +596,11 @@ class WorldModelInterface(OntologyInterface, WorldModelAbstractInterface):
         # Merge the tuples with an overlapping key
         if overlap_keys:
             loop = True
-            iters = 5
+            iters = 15
             while loop:  # Iterate until no shared keys are found
                 iters -= 1
                 if iters == 0:
-                    raise
+                    raise BaseException("Reached maximum number of iterations when merging keys")
                 loop = False
                 coupled_keys2 = []
                 merged = {}


### PR DESCRIPTION
- When having many preconditions 5 iterations are not enough
- Exception was not thrown correctly