### PR TITLE
New: Blackboard "unsetting" - Primitive does not sync Elements with no id

### DIFF
--- a/skiros2_common/src/skiros2_common/core/primitive.py
+++ b/skiros2_common/src/skiros2_common/core/primitive.py
@@ -43,7 +43,7 @@ class PrimitiveBase(SkillCore):
         @param      time  The time to evaluate if a parameter was changed
         """
         for k, p in self.params.items():
-            if p.dataTypeIs(Element()) and p.hasChanges(time):
+            if p.dataTypeIs(Element()) and p.hasChanges(time) and p.getValue().getIdNumber() >= 0:
                 vs = p.values
                 for i, e in enumerate(vs):
                     if not e.isAbstract():


### PR DESCRIPTION
One way to "unset" a blackboard parameter is to remove its ID. However then we add it a to the WM as a new element and it does not fulfill the purpose.
This prevents that we add these types of elements to the WM.

Discussion in https://github.com/RVMI/skiros2/issues/57