### PR TITLE
Fix: Use getIdNumber function in conditions.py

### DIFF
--- a/skiros2_common/src/skiros2_common/core/conditions.py
+++ b/skiros2_common/src/skiros2_common/core/conditions.py
@@ -754,7 +754,7 @@ class ConditionOnType(ConditionBase):
 
     def setDesiredState(self, ph):
         e = ph.getParamValue(self._subject_key)
-        if e.id >= 0:
+        if e.getIdNumber() >= 0:
             return
         else:
             e._type = self._value


### PR DESCRIPTION
It can happen that there is no proper ID for an element