### PR TITLE
New: Fails on failing preconditions

### DIFF
--- a/skiros2_skill/src/skiros2_skill/core/skill_utils.py
+++ b/skiros2_skill/src/skiros2_skill/core/skill_utils.py
@@ -269,7 +269,7 @@ class NodeExecutor():
         self.init(skill)
         if not self._ground(skill):
             if not self.tryOther(skill):
-                return State.Idle
+                return State.Failure
         skill.wrapper_expand()
         state = self._execute(skill)
         if self._verbose:


### PR DESCRIPTION
A skill (description) will fail instead of being idle. If it is only idle, there is little feedback for the user and the GUI gets stuck.
Credits go to Pontus Rosqvist.

From a normal user perspective, this is a very useful change. However I am not quite sure what the `idle` state means. Maybe this change has implications that I am not seeing.