### PR TITLE
Fix: Check length of task before access

### DIFF
--- a/skiros2_skill/src/skiros2_skill/ros/skill_manager_interface.py
+++ b/skiros2_skill/src/skiros2_skill/ros/skill_manager_interface.py
@@ -31,7 +31,10 @@ class SkillManagerInterface:
 
     @property
     def task(self):
-        return self.tasks[0]
+        if len(self.tasks) > 0:
+            return self.tasks[0]
+        else:
+            return -1
 
     @property
     def tasks(self):


### PR DESCRIPTION
There are circumstances under which the tasks list is empty, but will be accessed. E.g. when restarting the skill manager, but not the GUI.