### PR TITLE
New: Adds better feedback on wrong return values.

### DIFF
--- a/skiros2_common/src/skiros2_common/core/abstract_skill.py
+++ b/skiros2_common/src/skiros2_common/core/abstract_skill.py
@@ -429,6 +429,7 @@ class SkillCore(SkillDescription):
             self._setState(State.Running)
             self._setProgress("Start", 0)
         else:
+            log.warn("start", "onStart function of skill {} did not succeed.".format(self.label))
             self._setState(State.Failure)
         return self._state
 

--- a/skiros2_common/src/skiros2_common/core/primitive.py
+++ b/skiros2_common/src/skiros2_common/core/primitive.py
@@ -20,6 +20,8 @@ class PrimitiveBase(SkillCore):
             start_time = datetime.now()
             with self._avg_time_keeper:
                 return_state = self.execute()
+                if return_state is not State:
+                    raise ValueError("The return type of the 'execute' function must be one of {}: running, success, failure.".format(State))
                 assert type(return_state) == State
                 self._setState(return_state)
                 self._updateRoutine(start_time)


### PR DESCRIPTION
Before, a failing "onStart" was difficult to detect. Also if no return value was provided.
A wrong 'execute' return value resulted in a failing assertion.

When "onStart" does not succeed, only this feedback was provided by SkiROS:

```
[BtTicker]          Execution starts.
[VisitorStart]      Root-task_43(State.Running)[]
[Autoparametrize]   Resolving skiros:KpListener:['Robot']
MatchWm             skiros:KpListener:[Robot=cora:Robot-1-cp:ur5e_robot]
[VisitorStart]      KpListener-kp_listener(State.Failure)[Keypoints:[] MaxAge:[0.2] Robot: cora:Robot-1-cp:ur5e_robot ]
[VisitorExecute]    Root-task_43(State.Failure)[]
[BtTicker]          Execution stops.
```

I would not expect that people actively build a failing "onStart" function in their program flow.
If this would be the case, the warning should only be given if it is something else than "False" to help the people who forget the return value.