### PR TITLE
Fix: Enable automatic skill selection if grounding fails

### DIFF
--- a/skiros2_skill/src/skiros2_skill/core/skill_instanciator.py
+++ b/skiros2_skill/src/skiros2_skill/core/skill_instanciator.py
@@ -68,7 +68,7 @@ class SkillInstanciator:
         """
         to_set = None
         for p in self._available_instances[skill.type]:
-            if (p.label == skill.label or skill.label == "") and p.label not in ignore_list:
+            if (p.label == skill._label or skill._label == "") and p.label not in ignore_list:
                 to_set = p
                 if not p.hasState(State.Running):  # The skill is available, just go forward
                     break
@@ -76,8 +76,8 @@ class SkillInstanciator:
             if to_set.hasState(State.Running):  # The skill instance is busy, create a new one
                 to_set = self.duplicate_instance(to_set)
             skill.setInstance(to_set)
-        elif skill.label != "" and not ignore_list: # No instance exist, try to load it
-            skill.setInstance(self.add_instance(skill.label))
+        elif skill._label != "" and not ignore_list:  # No instance exist, try to load it
+            skill.setInstance(self.add_instance(skill._label))
         else:
             log.error("assign_instance", "No instance of type {} found.".format(skill.type))
             return False

--- a/skiros2_skill/src/skiros2_skill/core/skill_utils.py
+++ b/skiros2_skill/src/skiros2_skill/core/skill_utils.py
@@ -236,7 +236,7 @@ class NodeExecutor():
         """
         @brief If the skill label is not specified, try other instances
         """
-        if skill.label != "":
+        if skill._label != "":
             return False
         ignore_list = [skill._instance.label]
         while self._instanciator.assign_instance(skill, ignore_list):


### PR DESCRIPTION
Previously the implementation relied on the "label" property. However, this property is set to the concrete instance, even if the compound skill did not specify an instance.

To explain this a bit more:
I have a use-case in which I have a skill that runs in a loop for different work pieces. In one part of the procedure, a skill needs to be automatically chosen depending on preconditions on the material properties. So it is used without specifying an implementation:
```python
self.skill("MyFlexibleSkill", ""),
```
In the first iteration, it instantiates the correct implementation, but at a later point we might encounter a part that needs the other implementation & the grounding fails here:
https://github.com/RVMI/skiros2/blob/04353faa3f405ab970eb49915ce114354f9f5f94/skiros2_skill/src/skiros2_skill/core/skill_utils.py#L265-L272

This is fine, but when entering `tryOther`, a check is performed whether the label is set to be a specific skill:

https://github.com/RVMI/skiros2/blob/04353faa3f405ab970eb49915ce114354f9f5f94/skiros2_skill/src/skiros2_skill/core/skill_utils.py#L235-L240

Unfortunately this label is set to the currently set instance:

https://github.com/RVMI/skiros2/blob/04353faa3f405ab970eb49915ce114354f9f5f94/skiros2_skill/src/skiros2_skill/core/skill.py#L424-L430

Besides the entertaining comment, the `_label` property of the skill is still the original empty string and is not affected by the instance that was set before
So this PR proposes to use this instead.
