### PR TITLE
Compatibility with the ros_license_toolkit

### DIFF
--- a/.github/workflows/ros-license-check.yml
+++ b/.github/workflows/ros-license-check.yml
@@ -1,0 +1,15 @@
+name: Check Licenses
+
+on:
+  push:
+    branches: [ "master", "pr_license"]
+  pull_request:
+    branches: [ "master"]
+
+jobs:
+  check_licenses:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: matthias-mayr/ros_license_toolkit@1.2.3

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,3 @@
-SkiROS2 - Skill-based platform for ROS v2
-
-Software License Agreement (L-GPL License)
-
-Copyright (C) 2018 RiACT ApS
-
-Authors: Francesco Rovida, Bjarne Grossmann
-
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or

--- a/skiros2/CHANGELOG.rst
+++ b/skiros2/CHANGELOG.rst
@@ -72,7 +72,7 @@ Changelog for package skiros2
 * Finish plan-in-the-tree
 * Added extra properties to test robot hardware
 * Changed test camera type
-* Changed license to L-GPL and updated changelog
+* Changed license to LGPL-3.0-or-later and updated changelog
 * Updated version and changelog file
 * Contributors: Matthias Mayr, RvmiLab, Francesco Rovida
 

--- a/skiros2/package.xml
+++ b/skiros2/package.xml
@@ -8,7 +8,7 @@
 
   <maintainer email="francesco@m-tech.aau.dk">Francesco Rovida</maintainer>
   <maintainer email="bjarne@m-tech.aau.dk">Bjarne Grossmann</maintainer>
-  <license>L-GPL</license>
+  <license>LGPL-3.0-or-later</license>
 
   <author email="francesco@m-tech.aau.dk">Francesco Rovida</author>
   <author>Francesco Rovida</author>

--- a/skiros2_common/package.xml
+++ b/skiros2_common/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="francesco@m-tech.aau.dk">Francesco Rovida</maintainer>
   <maintainer email="bjarne@m-tech.aau.dk">Bjarne Grossmann</maintainer>
-  <license>L-GPL</license>
+  <license>LGPL-3.0-or-later</license>
   <author email="francesco@m-tech.aau.dk">Francesco Rovida</author>
   <author>Francesco Rovida</author>
 

--- a/skiros2_gui/CHANGELOG.rst
+++ b/skiros2_gui/CHANGELOG.rst
@@ -86,7 +86,7 @@ Changelog for package skiros2_gui
 * Added timeout to kill blocked BTs. Minor improvements on GUI
 * GUI improvements: BT execution visualization and more intuitive interface
 * Implemented visualization of active tasks
-* Changed license to L-GPL and updated changelog
+* Changed license to LGPL-3.0-or-later and updated changelog
 * Updated version and changelog file
 * Contributors: Francesco Rovida, Matthias Mayr, Francesco Rovida
 

--- a/skiros2_gui/package.xml
+++ b/skiros2_gui/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="francesco@m-tech.aau.dk">Francesco Rovida</maintainer>
   <maintainer email="bjarne@m-tech.aau.dk">Bjarne Grossmann</maintainer>
-  <license>L-GPL</license>
+  <license>LGPL-3.0-or-later</license>
   <author email="francesco@m-tech.aau.dk">Francesco Rovida</author>
   <author>Francesco Rovida</author>
 

--- a/skiros2_msgs/CHANGELOG.rst
+++ b/skiros2_msgs/CHANGELOG.rst
@@ -37,7 +37,7 @@ Changelog for package skiros2_msgs
 * Merged 'develop' into 'pycodestyle'.
 * Finish plan-in-the-tree
 * GUI improvements: BT execution visualization and more intuitive interface
-* Changed license to L-GPL and updated changelog
+* Changed license to LGPL-3.0-or-later and updated changelog
 * Updated version and changelog file
 * Contributors: Matthias Mayr, Francesco Rovida
 

--- a/skiros2_msgs/package.xml
+++ b/skiros2_msgs/package.xml
@@ -7,7 +7,7 @@
   </description>
   <maintainer email="francesco@m-tech.aau.dk">Francesco Rovida</maintainer>
   <maintainer email="bjarne@m-tech.aau.dk">Bjarne Grossmann</maintainer>
-  <license>L-GPL</license>
+  <license>LGPL-3.0-or-later</license>
   <author email="francesco@m-tech.aau.dk">Francesco Rovida</author>
   <author>Francesco Rovida</author>
 

--- a/skiros2_skill/package.xml
+++ b/skiros2_skill/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="francesco@m-tech.aau.dk">Francesco Rovida</maintainer>
   <maintainer email="bjarne@m-tech.aau.dk">Bjarne Grossmann</maintainer>
-  <license>L-GPL</license>
+  <license>LGPL-3.0-or-later</license>
   <author email="francesco@m-tech.aau.dk">Francesco Rovida</author>
   <author>Francesco Rovida</author>
 

--- a/skiros2_task/package.xml
+++ b/skiros2_task/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="francesco@m-tech.aau.dk">Francesco Rovida</maintainer>
   <maintainer email="bjarne@m-tech.aau.dk">Bjarne Grossmann</maintainer>
-  <license>L-GPL</license>
+  <license>LGPL-3.0-or-later</license>
   <author email="francesco@m-tech.aau.dk">Francesco Rovida</author>
   <author>Francesco Rovida</author>
 

--- a/skiros2_world_model/package.xml
+++ b/skiros2_world_model/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="francesco@m-tech.aau.dk">Francesco Rovida</maintainer>
   <maintainer email="bjarne@m-tech.aau.dk">Bjarne Grossmann</maintainer>
-  <license>L-GPL</license>
+  <license>LGPL-3.0-or-later</license>
   <author email="francesco@m-tech.aau.dk">Francesco Rovida</author>
   <author>Francesco Rovida</author>
 


### PR DESCRIPTION
- Makes the licenses compatible with the [ros_license_toolkit](https://github.com/boschresearch/ros_license_toolkit)
- I had to remove the preamble of the license for that
- Adds a github workflow to check license compatibility on a regular basis
  - This needs to be adapted as soon as [this PR](https://github.com/boschresearch/ros_license_toolkit/pull/46) is accepted

@frvd and @Bjarne-RiACT: I changed the license text to make it compatible with the tool. Is that alright with you?