### PR TITLE
Improved WM element (ID) handling

### DIFF
--- a/skiros2_common/src/skiros2_common/core/world_element.py
+++ b/skiros2_common/src/skiros2_common/core/world_element.py
@@ -150,9 +150,13 @@ class Element(object):
         """
         @brief Return the element id number as integer
         """
-        if self._id.find('-') < 0:
+        hash_pos = self._id.find('#')
+        # Search after # if there is one
+        if hash_pos == -1:
+            hash_pos = 0
+        if self._id.find("-", hash_pos) < 0:
             return -1
-        return int(self._id.split('-')[1])
+        return int((self._id[hash_pos:]).split('-')[1])
 
     def setUri(self, eid):
         self._setLastUpdate()

--- a/skiros2_world_model/src/skiros2_world_model/core/ontology_rdflib.py
+++ b/skiros2_world_model/src/skiros2_world_model/core/ontology_rdflib.py
@@ -67,11 +67,11 @@ class Ontology:
         if name == "":
             return None
         if name.find("#") > 0:
-            return name
+            return rdflib.term.URIRef(name)
         if name.find(":") < 1:
             if name.find(":") == 0:
                 name = name[1:]
-            return self.add_default_prefix(name)
+            return rdflib.term.URIRef(self.add_default_prefix(name))
         tokens = name.split(":")
         for prefix, uri in self._ontology.namespaces():
             if tokens[0] == prefix:

--- a/skiros2_world_model/src/skiros2_world_model/core/world_model.py
+++ b/skiros2_world_model/src/skiros2_world_model/core/world_model.py
@@ -548,9 +548,10 @@ class WorldModel(IndividualsDataset):
         return uri.split('-')[0]
 
     def _uri2id(self, uri):
-        if uri.find('-') < 0:
+        hash_pos = uri.find('#')
+        if hash_pos < 0 or uri.find("-", hash_pos) < 0:
             return -1
-        return int(uri.split('-')[1])
+        return int((uri[hash_pos:]).split('-')[1])
 
     @synchronized
     def load_context(self, filename):


### PR DESCRIPTION
When testing, I ran into two issues that are addressed in this PR.

1. The `lightstring2uri` method could return a string instead of an rdflib `URIRef`. This caused errors of this kind:
```
/wm: AauSpatialReasoner  warn: Adding relation to http://www.inf.ufrgs.br/phi-group/ontologies/cora.owl#Robot-1-skiros:test_robot
/wm: statement to add ('http://www.inf.ufrgs.br/phi-group/ontologies/cora.owl#Robot-1', rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Named
  ~  Individual'))
/test_robot: Service call failed: service [/wm/modify] responded with an error: b'error processing request: Subject http://www.inf.ufrgs.br/phi-group/ontologies/cora.owl#Robot-1must be an rdflib term'
```

2. When obtaining the ID number from an element, it was assumed that there is no dash "-" other than the separator between type and ID in the URI.
Since we have URIs like `http://www.inf.ufrgs.br/phi-group/ontologies/cora.owl#Robot-1`, this could lead to errors like:
```
File "/home/matthias/Workspaces/skiros2_noetic_ws/src/skiros2/skiros2_world_model/src/skiros2_world_model/core/world_model.py", line 557, in _uri2id\n    return int(uri.split
   ~  (\'-\')[1])\n', "ValueError: invalid literal for int() with base 10: 'group/ontologies/cora.owl#Robot'\n"]
/test_robot: Service call failed: service [/wm/modify] responded with an error: b"error processing request: invalid literal for int() with base 10: 'group/ontologies/cora.owl#Robot'"
```

This two commits address both. However, I am not sure if they would cause side effects.
@frovida: If you have sth to comment, please do so.

I will merge them into the ROS 2 branch, so they would get some sort of testing.   
This also came up when "reviving" the skiros2_test_lib. Once it's fully up, we can also make changes with some more confidence.
