### PR TITLE
Fix: Explicitly define "packages" in skiros2 setup.py

### DIFF
--- a/skiros2/setup.py
+++ b/skiros2/setup.py
@@ -6,6 +6,7 @@ package_name = 'skiros2'
 
 setup(
     name=package_name,
+    packages=[],
     version='1.0.5',
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),


### PR DESCRIPTION
Otherwise building fails with "error: Multiple top-level packages discovered in a flat-layout: ['cfg', 'owl', 'res', 'launch', 'resource']."

To be checked if this causes issues in humble.