### PR TITLE
Fix: Launch rqt with SkiROS2 GUI

### DIFF
--- a/skiros2/launch/skiros2.launch.py
+++ b/skiros2/launch/skiros2.launch.py
@@ -100,7 +100,7 @@ def generate_launch_description():
 
     gui = Node(package='rqt_gui',
                executable='rqt_gui',
-               # arguments=["-s skiros2_gui.gui.Skiros"], # does not find the plugin. Not sure why - it appears in the list and can be selected with "ros2 run"
+               arguments=["-s", "skiros2_gui"],
                output='screen')
     
     skill_mgr = Node(package='skiros2_skill',


### PR DESCRIPTION
Solution for starting up the GUI directly. Works for me on Jazzy.