### PR TITLE
Fix: ignore skills not in list

### DIFF
--- a/skiros2_task/skiros2_task/ros/task_manager.py
+++ b/skiros2_task/skiros2_task/ros/task_manager.py
@@ -154,6 +154,8 @@ class TaskManagerNode(PrettyObject, Node):
     def initDomain(self):
         skills = self._wmi.resolve_elements(wmi.Element(":Skill"))
         for skill in skills:
+            if skill.label not in self.skills:
+                continue
             params = {}
             preconds = []
             holdconds = []


### PR DESCRIPTION
Skills unavailable for planning were accidentally still available for planning.

They are (correctly) not available when constructing the BT but all skills were used when constructing the domain, with this the unavailable skills are not serialized when constructing the PDDL domain